### PR TITLE
Implement Exception Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+Changes in Comparison to main
+=============================
+- PerTag patch
+- Battery Indicator
+- Gapless Tiling with offset
+- Added MOD_WIN support as Mod key instead of ALT
+- Cyclic check for Hung windows with clock Timer to call unmanage()
+
 dwm-win32 is a port of the well known X11 window manager dwm to Microsoft
 Windows.
 
@@ -45,15 +53,13 @@ Usage
 
   `MOD + Control + b`  Toggles bar on and off.
 
-  `MOD + e` Toogles windows explorer and taskbar on and off.
+  `MOD + Shift + e` Toogles windows explorer and taskbar on and off.
 
   `MOD + t` Sets tiled layout.
 
   `MOD + f` Sets floating layout.
 
   `MOD + m` Sets monocle layout.
-
-  `MOD + Control + space` Toggles between current and previous layout.
 
   `MOD + j` Focus next window.
 
@@ -65,15 +71,15 @@ Usage
 
   `MOD + Control + Return` Zooms/cycles focused window to/from master area (tiled layouts only).
 
-  `MOD + Shift + c` Close focused window.
+  `MOD + q` Close focused window.
 
-  `MOD + Shift + a` Force rearrange.
+  `MOD + Shift + f` Force rearrange.
 
   `MOD + Shift + Space` Toggle focused window between tiled and floating state.
 
   `MOD + n` Toggles border of currently focused window.
 
-  `Mod + i` Display classname of currently focused window, useful for writing
+  `Mod + + Shift + i` Display classname of currently focused window, useful for writing
      tagging rules.
 
   `MOD + Tab` Toggles to the previously selected tags.
@@ -96,7 +102,7 @@ Usage
 
   `MOD + Control + q`  Quit dwm.
 
-  `MOD + Control + l`  Log all window state.
+  `MOD + Control + l`  Log all window state. (Disabled)
 
 
  ## Mouse

--- a/config.h.in
+++ b/config.h.in
@@ -1,146 +1,191 @@
 /* See LICENSE file for copyright and license details. */
+#define DEBUG \
+    $ { DEBUG }
+    
+#define PROJECT_NAME "@PROJECT_NAME@"
+#define PROJECT_VER "@PROJECT_VERSION@"
+#define PROJECT_VER_MAJOR "@PROJECT_VERSION_MAJOR@"
+#define PROJECT_VER_MINOR "@PROJECT_VERSION_MINOR@"
+#define PTOJECT_VER_PATCH "@PROJECT_VERSION_PATCH@"
 
-static const wchar_t *fontname         = L"Fira Code";
-static const unsigned int fontsize  = 20;
+/*Hack Regular Nerd Font Complete Windows Compatible*/
+static const wchar_t *fontname = L"Hack NF";
+static const unsigned int fontsize = 16;
 
-/* appearance, colors are specified in the form 0x00bbggrr or with the RGB(r, g, b) macro */
-#define normbordercolor 0x00444444
-#define normbgcolor     0x00222222
-#define normfgcolor     0x00bbbbbb
-#define selbordercolor  0x00775500
-#define selbgcolor      0x00775500
-#define selfgcolor      0x00eeeeee
+/* appearance, colors are specified in the form 0x00bbggrr or with the RGB(r, g,
+ * b) macro */
+#define normbordercolor 0x008f8393
+#define normbgcolor 0x000d0c17
+#define normfgcolor 0x00cdbcd2
+#define selbordercolor 0x00cdbcd2
+#define selbgcolor 0x004C4357
+#define selfgcolor 0x00cdbcd2
 
-static const unsigned int borderpx    = 0;        /* border pixel of windows */
-static const unsigned int textmargin  = 15;       /* margin for the text displayed on the bar */
-static bool showbar                   = true;     /* false means no bar */
-static bool topbar                    = true;     /* false means bottom bar */
-static bool showclock                 = true;     /* false means no clock */
-static bool showutcclock              = true;     /* false means no utc clock */
-static bool showexploreronstart       = false;    /* false means do not show explorer/task bar on start */
+static const unsigned int borderpx = 0; /* border pixel of windows */
+static const unsigned int textmargin =
+    14;                           /* margin for the text displayed on the bar */
+static bool showbar = true;       /* false means no bar */
+static bool topbar = true;        /* false means bottom bar */
+static bool showclock = true;     /* false means no clock */
+static bool showutcclock = false; /* false means no utc clock */
+static bool showexploreronstart = true; /* false means do not show explorer/task bar on start */
+static bool showBattery = true;
 
 /* tagging */
-static const wchar_t tags[][MAXTAGLEN] = { L"1", L"2", L"3", L"4", L"5", L"6", L"7", L"8", L"9" };
+static const wchar_t tags[][MAXTAGLEN] = {L"1", L"2", L"3", L"4", L"5",
+                                          L"6", L"7", L"8", L"9"};
 static unsigned int tagset[] = {1, 1}; /* after start, first tag is selected */
 
 static Rule rules[] = {
-    /* class                                 title               processname        tags mask   isfloating      ignoreborder */
-    { L"MultitaskingViewFrame",              NULL,                  NULL,               0,          true,           true },
-    { L"MSCTFIME UI",                        NULL,                  NULL,               0,          true,           true },
-    { L"Microsoft-Windows-SnipperToolbar",   L"Snipping Tool",      NULL,               0,          true,           true },
-    { L"Microsoft Text Input Application",   NULL,                  NULL,               0,          true,           true },
-    { L"MSO_BORDEREFFECT_WINDOW_CLASS",      NULL,                  NULL,               0,          true,           true },
-    { L"CASCADIA_HOSTING_WINDOW_CLASS",      NULL,                  NULL,               0,          false,          true },
-    { L"ThumbnailDeviceHelperWnd",           NULL,                  NULL,               0,          true,           true },
-    { L"EdgeUiInputTopWndClass",             NULL,                  NULL,               0,          true,           true },
-    { L"CabinetWClass",                      NULL,                  NULL,               0,          false,          true }, /* file explorer */
-    { L"OperationStatusWindow",              NULL,                  NULL,               0,          false,          true }, /* explorer copy window */
-    { L"EXCEL",                              NULL,                  L"EXCEL.EXE",       1,          false,          true }, /* Excel */
-    { L"PPTFrameClass",                      NULL,                  NULL,               0,          false,          true }, /* PowerPoint */
-    { L"OpusApp",                            NULL,                  NULL,               0,          false,          true }, /* Word */
-    { NULL,                                  L"OneNote",            NULL,               0,          false,          true }, /* OneNote */
-    { NULL,                                  L"Snip & Sketch",      NULL,               0,          true,           true },
-    { L"Chrome_WidgetWin_1",                 L"Google Chrome",      NULL,               0,          false,          true },
-    { L"Chrome_WidgetWin_1",                 L"Visual Studio Code", NULL,               0,          false,          true },
-    { NULL,                                  L"vimrun.exe",         NULL,               0,          true,           true },
-    { NULL,                                  NULL,                  L"Spyglass.exe",               0,          true,           true }, /* https://github.com/a5huynh/spyglass */
-    { L"TaskManagerWindow",                  NULL,                  NULL,               0,          true,           true },
-};
+    /* class                                 title                  processname        tags mask   isfloating      ignoreborder */
+    { L"MultitaskingViewFrame",              NULL,                    NULL,               0,          true,           true },
+    { L"MSCTFIME UI",                        NULL,                    NULL,               0,          true,           true },
+    { L"Microsoft-Windows-SnipperToolbar",   L"Snipping Tool",        NULL,               0,          true,           true },
+    { L"Microsoft Text Input Application",   NULL,                    NULL,               0,          true,           true },
+    { L"MSO_BORDEREFFECT_WINDOW_CLASS",      NULL,                    NULL,               0,          true,           true },
+    { L"CASCADIA_HOSTING_WINDOW_CLASS",      NULL,                    NULL,               0,          false,          true },
+    { L"ThumbnailDeviceHelperWnd",           NULL,                    NULL,               0,          true,           true },
+    { L"EdgeUiInputTopWndClass",             NULL,                    NULL,               0,          true,           true },
+    { L"CabinetWClass",                      NULL,                    NULL,               0,          false,          true }, /* file explorer */
+    { L"OperationStatusWindow",              NULL,                    NULL,               0,          false,          true }, /* explorer copy window */
+    { L"EXCEL",                              NULL,                    L"EXCEL.EXE",       0,          true,          true }, /* Excel */
+    { L"XLMAIN",                             NULL,                    L"C:\Program Files\Microsoft Office\root\Office16\EXCEL.EXE",       0,          true,          true }, /* Excel */
+    { L"XLMAIN",                             NULL,                    NULL,               0,          true,          true }, /* Excel */
+    { L"PPTFrameClass",                      NULL,                    NULL,               0,          false,          true }, /* PowerPoint */
+    { L"OpusApp",                            NULL,                    NULL,               0,          false,          true }, /* Word */
+    { NULL,                                  L"OneNote",              NULL,               0,          false,          true }, /* OneNote */
+    { NULL,                                  L"Snip & Sketch",        NULL,               0,          true,           true },
+    { L"Chrome_WidgetWin_1",                 L"Google Chrome",        NULL,               0,          false,          true },
+    { L"Chrome_WidgetWin_1",                 L"Visual Studio Code",   NULL,               0,          false,          true },
+    { L"Chrome_WidgetWin_1",                 L"New Tab - Brave",      L"BRAVE.EXE",       0,          false,          true },
+    { L"Chrome_WidgetWin_1",                 NULL,                    L"BRAVE.EXE",       0,          false,          true },
+    { L"Chrome_WidgetWin_1",                 L"Discord Updater",      NULL,               2,          true,           true },
+    { L"Chrome_WidgetWin_1",                 L"- Discord",            NULL,               2,          false,          true },
+    { L"Chrome_WidgetWin_1",                 L"WhatsApp",             NULL,               0,          true,           true },
+    { L"Chrome_WidgetWin_1",                 L"Rambox",             	NULL,               2,          true,           true },
+    { NULL,                                  L"Rambox.exe",           NULL,               2,          true,           true },
+    { NULL,                                  L"vimrun.exe",           NULL,               0,          true,           true },
+    { NULL,                                  L"spyglass",             NULL,               0,          true,           true }, /* https://github.com/a5huynh/spyglass */
+    { L"TaskManagerWindow",                  NULL,                    NULL,               0,          true,           true },
+    { L"Windows.Ul.Core.CoreWindow",         NULL,                    NULL,               0,          true,           true },
+    { L"Windows.Ul.Core.CoreWindow",         NULL,                    L"ShellExperienceHost.exe",   0, true,           true },
+    { L"Progman",                            NULL,                    NULL,               0,          true,           true },
+    { L"CiscoUIFrame",                       L"Cisco Webex Meetings", NULL,               2,          true,           true },
+    { L"CiscoUIFrame",                       L"Webex",                NULL,               2,          true,           true },
+    { L"WorkerW",                            NULL,		           NULL,               0,          true,           true },
+    { L"QWidget",                            NULL,		           L"GoldenDict.exe",  0,          true,           false },
+    { NULL,                            	  NULL,		           L"Files.exe",	    0,         	false,          true },
+    { L"ytWindow",					  NULL,                    NULL,               0,          true,           true },
+    { NULL,              				  NULL,                    L"flux.exe",        0,          true,           true },
+    { NULL,              				  NULL,                    L"7zG.exe",         0,          true,           true },
+    { NULL,              				  L"VocabSieve v0.10.1",   NULL,         	    0,          true,           true },
+    { L"Qt5152QWindowIcon",              	  NULL,				NULL,         	    0,          true,           true },
+    { L"MagUIClass",              	  	  NULL,				NULL,         	    0,          true,           true },
+    { NULL,              	  			  NULL,				L"Magnify.exe",     0,          true,           true },
+    { NULL,              	  			  NULL,				L"sideloadly.exe",  0,          true,           true },
+    { L"OperationStatusWindow",              NULL,				NULL,         	    0,          true,           true },
+    { NULL,						  NULL,			L"PowerToys.Peek.UI.exe",0,          true,           true },
+    { NULL,						  NULL,			L"PowerToys.MeasureToolUI.exe",0,    true,           false },
+    { NULL,						  NULL,			L"pc-client.exe",0,          		true,           false },
+    { NULL,						  NULL,			L"csc_ui.exe",0,          			true,           false },
+   };
 
 /* layout(s) */
-static float mfact      = 0.55; /* factor of master area size [0.05..0.95] */
+static float mfact = 0.55; /* factor of master area size [0.05..0.95] */
 
 #include "bstack.c"
-#include "grid.c"
-#include "gaplessgrid.c"
 #include "fibonacci.c"
+#include "gaplessgrid.c"
+#include "grid.c"
 
 static Layout layouts[] = {
     /* symbol     arrange function */
-    { L"[]=",      tile },    /* first entry is default */
-    { L"><>",      NULL },    /* no layout function means floating behavior */
-    { L"[M]",      monocle },
-    { L"TTT",      bstack },
-    { L"###",      gaplessgrid },
-    { L"+++",      grid },
-    { L"(@)",      spiral },
-    { L"[\\]",     dwindle },
+    {L"T", tile}, /* first entry is default */
+    {L"F", NULL}, /* no layout function means floating behavior */
+    {L"M", monocle}, {L"TTT", bstack}, {L"G", gaplessgrid},
+    {L"+++", grid},  {L"(@)", spiral}, {L"[\\]", dwindle},
 };
 
-/* key definitions */
-#define MODKEY           (MOD_ALT)
-#define TAGKEYS(KEY,TAG) \
-    { MODKEY,                       KEY,      view,           {.ui = 1 << TAG} }, \
-    { MODKEY|MOD_CONTROL,           KEY,      toggleview,     {.ui = 1 << TAG} }, \
-    { MODKEY|MOD_SHIFT,             KEY,      tag,            {.ui = 1 << TAG} }, \
-    { MODKEY|MOD_CONTROL|MOD_SHIFT, KEY,      toggletag,      {.ui = 1 << TAG} },
+// static Layout layouts[] = {
+//     /* symbol     arrange function */
+//     {L"[ ]=", tile}, /* first entry is default */
+//     {L"><>", NULL},  /* no layout function means floating behavior */
+//     {L"[M]", monocle}, {L"TTT", bstack}, {L"###", gaplessgrid},
+//     {L"+++", grid},    {L"(@)", spiral}, {L"[\\]", dwindle},
+// };
 
-static wchar_t clockfmt[] = L"%m/%d/%Y %a %H:%M";
+/* key definitions */
+#define MODKEY (MOD_WIN)
+#define TAGKEYS(KEY, TAG)                                                      \
+  {MODKEY, KEY, view, {.ui = 1 << TAG}},                                       \
+      {MODKEY | MOD_CONTROL, KEY, toggleview, {.ui = 1 << TAG}},               \
+      {MODKEY | MOD_SHIFT, KEY, tag, {.ui = 1 << TAG}},                        \
+      {MODKEY | MOD_CONTROL | MOD_SHIFT, KEY, toggletag, {.ui = 1 << TAG}},
+
+static wchar_t clockfmt[] = L"| %a %d/%m | %I:%M %p";
 static int clock_interval = 15000;
 
 /* helper for spawning shell commands in the pre dwm-5.0 fashion */
-#define SHCMD(cmd) { .v = (const wchar_t*[]){ L"/bin/sh", L"-c", cmd, NULL } }
+#define SHCMD(cmd)                                                             \
+  {                                                                            \
+    .v = (const wchar_t *[]) { L"/bin/sh", L"-c", cmd, NULL }                  \
+  }
 
 /* commands */
-static const wchar_t *termcmd[]  = { L"wt.exe", NULL };
+static const wchar_t *explorer[] = {L"explorer.exe", NULL};
+
 
 static Key keys[] = {
     /* modifier                     key        function             argument */
-    { 0 }, // ??? dummy empty
-    { MODKEY|MOD_SHIFT,             VK_RETURN, spawn,               {.v = termcmd } },
-    { MODKEY|MOD_CONTROL,           'B',       togglebar,           {0} },
-    { MODKEY,                       'J',       focusstack,          {.i = +1 } },
-    { MODKEY,                       'K',       focusstack,          {.i = -1 } },
-    { MODKEY|MOD_SHIFT,             'J',       movestack,           {.i = +1 } },
-    { MODKEY|MOD_SHIFT,             'K',       movestack,           {.i = -1 } },
-    { MODKEY|MOD_SHIFT,             'A',       forcearrange,        {.i = -1 } },
-    { MODKEY,                       'H',       setmfact,            {.f = -0.05} },
-    { MODKEY,                       'L',       setmfact,            {.f = +0.05} },
-    { MODKEY,                       'I',       showclientinfo,      {0} },
-    { MODKEY|MOD_CONTROL,           VK_RETURN, zoom,                {0} },
-    { MODKEY,                       VK_TAB,    view,                {0} },
-    { MODKEY|MOD_SHIFT,             'C',       killclient,          {0} },
-    { MODKEY,                       'T',       setlayout,           {.v = &layouts[0]} },
-    { MODKEY,                       'F',       setlayout,           {.v = &layouts[1]} },
-    { MODKEY,                       'M',       setlayout,           {.v = &layouts[2]} },
-    { MODKEY,                       'B',       setlayout,           {.v = &layouts[3]} },
-    { MODKEY,                       'G',       setlayout,           {.v = &layouts[4]} },
-    { MODKEY|MOD_SHIFT,             'G',       setlayout,           {.v = &layouts[5]} },
-    { MODKEY,                       'D',       setlayout,           {.v = &layouts[6]} },
-    { MODKEY|MOD_SHIFT,             'D',       setlayout,           {.v = &layouts[7]} },
-    { MODKEY|MOD_CONTROL,           VK_SPACE,  setlayout,           {0} },
-    { MODKEY|MOD_SHIFT,             VK_SPACE,  togglefloating,      {0} },
-    { MODKEY,                       'N',       toggleborder,        {0} },
-    { MODKEY,                       'E',       toggleexplorer,      {0} },
-    { MODKEY|MOD_CONTROL,           'L',       writelog,            {0} },
-    { MODKEY,                       '0',       view,                {.ui = ~0 } },
-    { MODKEY|MOD_SHIFT,             '0',       tag,                 {.ui = ~0 } },
-    TAGKEYS(                        '1',                            0)
-    TAGKEYS(                        '2',                            1)
-    TAGKEYS(                        '3',                            2)
-    TAGKEYS(                        '4',                            3)
-    TAGKEYS(                        '5',                            4)
-    TAGKEYS(                        '6',                            5)
-    TAGKEYS(                        '7',                            6)
-    TAGKEYS(                        '8',                            7)
-    TAGKEYS(                        '9',                            8)
-    { MODKEY|MOD_CONTROL,           'Q',       quit,                {0} },
+    //     {0}, // ??? dummy empty
+    {MODKEY | MOD_CONTROL, 'B', togglebar, {0}},
+    {MODKEY, 'J', focusstack, {.i = +1}},
+    {MODKEY, 'K', focusstack, {.i = -1}},
+    {MODKEY | MOD_SHIFT, 'J', movestack, {.i = +1}},
+    {MODKEY | MOD_SHIFT, 'K', movestack, {.i = -1}},
+    {MODKEY, 'H', setmfact, {.f = -0.05}},
+    {MODKEY, 'L', setmfact, {.f = +0.05}},
+    {MOD_ALT, 'I', showclientinfo, {0}},
+    {MODKEY | MOD_CONTROL, VK_RETURN, zoom, {0}},
+    {MODKEY, VK_TAB, view, {0}},
+    {MODKEY, 'Q', killclient, {0}},
+    {MODKEY, 'T', setlayout, {.v = &layouts[0]}},
+    {MODKEY, 'F', setlayout, {.v = &layouts[1]}},
+    {MODKEY | MOD_SHIFT, 'F', forcearrange, {0}},
+    {MODKEY, 'M', setlayout, {.v = &layouts[2]}},
+    {MODKEY | MOD_CONTROL, 'T', setlayout, {.v = &layouts[3]}},
+    {MODKEY, 'G', setlayout, {.v = &layouts[4]}},
+    {MODKEY | MOD_SHIFT, 'G', setlayout, {.v = &layouts[5]}},
+    {MODKEY, 'D', setlayout, {.v = &layouts[6]}},
+    {MODKEY | MOD_SHIFT, 'D', setlayout, {.v = &layouts[7]}},
+    // {MODKEY | MOD_CONTROL, VK_SPACE, setlayout, {0}},
+    {MODKEY | MOD_SHIFT, VK_SPACE, togglefloating, {0}},
+    {MODKEY, 'N', toggleborder, {0}},
+    {MODKEY, 'E', spawn, {.v = explorer}},
+    {MODKEY | MOD_SHIFT, 'E', toggleexplorer, {0}},
+    // {MODKEY | MOD_CONTROL, 'L', writelog, {0}},
+    {MODKEY, '0', view, {.ui = ~0}},
+    {MODKEY | MOD_SHIFT, '0', tag, {.ui = ~0}},
+    TAGKEYS('1', 0) TAGKEYS('2', 1) TAGKEYS('3', 2) TAGKEYS('4', 3)
+        TAGKEYS('5', 4) TAGKEYS('6', 5) TAGKEYS('7', 6) TAGKEYS('8', 7)
+            TAGKEYS('9', 8){MODKEY | MOD_CONTROL, 'Q', quit, {0}},
 };
 
-
 /* button definitions */
-/* click can be a tag number (starting at 0), ClkLtSymbol, ClkStatusText or ClkWinTitle */
+/* click can be a tag number (starting at 0), ClkLtSymbol, ClkStatusText or
+ * ClkWinTitle */
 static Button buttons[] = {
-    /* click                button event type     modifier keys    function        argument */
-    { ClkLtSymbol,          WM_LBUTTONDOWN,       0,               setlayout,      {0} },
-    { ClkLtSymbol,          WM_RBUTTONDOWN,       0,               setlayout,      {.v = &layouts[2]} },
-    { ClkWinTitle,          WM_MBUTTONDOWN,       0,               zoom,           {0} },
-    { ClkStatusText,        WM_MBUTTONDOWN,       0,               spawn,          {.v = termcmd } },
+    /* click                button event type     modifier keys    function
+       argument */
+    {ClkLtSymbol, WM_LBUTTONDOWN, 0, setlayout, {0}},
+    {ClkLtSymbol, WM_RBUTTONDOWN, 0, setlayout, {.v = &layouts[2]}},
+    {ClkWinTitle, WM_MBUTTONDOWN, 0, zoom, {0}},
 #if 0
     { ClkClientWin,         WM_MBUTTONDOWN,       MODKEY,          togglefloating, {0} },
 #endif
-    { ClkTagBar,            WM_LBUTTONDOWN,       VK_MENU,         tag,            {0} },
-    { ClkTagBar,            WM_RBUTTONDOWN,       VK_MENU,         toggletag,      {0} },
-    { ClkTagBar,            WM_LBUTTONDOWN,       0,               view,           {0} },
-    { ClkTagBar,            WM_RBUTTONDOWN,       0,               toggleview,     {0} },
+    {ClkTagBar, WM_LBUTTONDOWN, VK_MENU, tag, {0}},
+    {ClkTagBar, WM_RBUTTONDOWN, VK_MENU, toggletag, {0}},
+    {ClkTagBar, WM_LBUTTONDOWN, 0, view, {0}},
+    {ClkTagBar, WM_RBUTTONDOWN, 0, toggleview, {0}},
 };
+

--- a/src/dwm-win32.c
+++ b/src/dwm-win32.c
@@ -917,7 +917,7 @@ resize(Client *c, int x, int y, int w, int h) {
         c->w = w;
         c->h = h;
         debug(L" resize %d: %s: x: %d y: %d w: %d h: %d\n", c->hwnd, getclienttitle(c->hwnd), x, y, w, h);
-        SetWindowPos(c->hwnd, HWND_TOP, c->x, c->y, c->w, c->h, SWP_NOACTIVATE);
+        SetWindowPos(c->hwnd, HWND_TOP, c->x - 7, c->y, c->w + 14, c->h + 7, SWP_NOACTIVATE);
     }
 }
 

--- a/src/dwm-win32.c
+++ b/src/dwm-win32.c
@@ -772,7 +772,7 @@ ismanageable(HWND hwnd) {
     if (iscloaked(hwnd))
         return false;
 
-    if (wcsstr(classname, L"Windows.UI.Core.CoreWindow") && (
+    if (wcsstr(classname, L"Windows.UI.Core.CoreWindow") || (
         wcsstr(title, L"Windows Shell Experience Host") ||
         wcsstr(title, L"Microsoft Text Input Application") ||
         wcsstr(title, L"Action center") ||

--- a/src/dwm-win32.c
+++ b/src/dwm-win32.c
@@ -390,6 +390,9 @@ drawbar(void) {
     wchar_t timestr[256];
     wchar_t localtimestr[256];
     wchar_t utctimestr[256];
+    wchar_t batterystr[256];
+    wchar_t out[256];
+
 
     for (c = clients; c; c = c->next) {
         occ |= c->tags;
@@ -435,11 +438,29 @@ drawbar(void) {
         } else {
             swprintf(timestr, sizeof(localtimestr), L"%ls", localtimestr);
         }
-
-        dc.w = TEXTW(timestr);
-        dc.x = ww - dc.w;
-        drawtext(timestr, dc.norm, false);
     }
+    // Battery status
+    if (showBattery) {
+        SYSTEM_POWER_STATUS status;
+        if (GetSystemPowerStatus(&status)) {
+            unsigned char battery = status.BatteryLifePercent;
+            /* battery := 0..100 or 255 if unknown */
+            if (battery != 255) {
+                if (status.ACLineStatus == 1) {
+                    swprintf(batterystr, sizeof(batterystr), L" | C %u%%", battery);
+                } else {
+                    swprintf(batterystr, sizeof(batterystr), L" | D %u%%", battery);
+                }
+            }
+        }
+    }
+  
+    // concatenate all the parts to create the final output string
+    wcscpy(out, timestr);
+    wcscat(out, batterystr);
+    dc.w = TEXTW(out);
+    dc.x = ww - dc.w;
+    drawtext(out, dc.norm, false);
 
     if ((dc.w = dc.x - x) > bh) {
         dc.x = x;

--- a/src/dwm-win32.c
+++ b/src/dwm-win32.c
@@ -1817,6 +1817,14 @@ void ReleaseHook()
     UnhookWindowsHookEx(_hook);
 }
 
+//catches unhandled exceptions and performs necessary cleanup before a crash, you can use Structured Exception Handling (SEH) in Windows
+// This function will be called when an exception occurs
+void cleanupOnException() {
+    Client *c;
+    for (c = clients; c; c = c->next) {
+        unmanage(c);
+    }
+}
 
 int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, int nShowCmd) {
 	SetProcessDPIAware();
@@ -1832,14 +1840,24 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLi
         die(L"dwm-win32 already running");
 
 	lua_State *L = luaL_newstate();
-    setup(L, hInstance);
 
-    while (GetMessage(&msg, NULL, 0, 0) > 0) {
-        TranslateMessage(&msg);
-        DispatchMessage(&msg);
+    // the __try block contains the main program code. If an unhandled exception occurs anywhere in this block, control immediately transfers to the __except block. The cleanupOnException function is then called to unmanage all windows before the program crashes.
+    // Establish an exception handler
+    __try {
+        setup(L, hInstance);
+
+        while (GetMessage(&msg, NULL, 0, 0) > 0) {
+            TranslateMessage(&msg);
+            DispatchMessage(&msg);
+        }
+
+        cleanup(L);
     }
-
-    cleanup(L);
+    
+    // Catch any unhandled exceptions
+    __except(EXCEPTION_EXECUTE_HANDLER) {
+        cleanupOnException();
+    }
 
     return msg.wParam;
 }


### PR DESCRIPTION
This implements Exception Handling: by using try-catch blocks to handle exceptions that might occur during the execution of dwm-win32. This allows us to call `unmanage()` on all windows before crashing, and thus not losing any programs.

The `__try` block contains the main program code. If an unhandled exception occurs anywhere in this block, control immediately transfers to the `__except` block. The `cleanupOnException` function is then called to unmanage all windows before the program crashes.